### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,11 @@ or
 Add the reporter to config
 --------------------------
 
-At the top of the `wdio.conf.js`-file, require the library:
-```
-const video = require('wdio-video-reporter');
-```
-
-Then add the video reporter to the configuration in the reporters property:
+Add the video reporter to the configuration in the reporters property:
 
 ```
  reporters: [
-    [video, {
+    ['video', {
       saveAllVideos: false,       // If true, also saves videos for successful test cases
       videoSlowdownMultiplier: 3, // Higher to get slower videos, lower for faster videos [Value 1-100]
     }],


### PR DESCRIPTION
Current install instructions don't work with the latest version (see https://github.com/webdriverio/webdriverio/issues/9869#issuecomment-1674985000 for discussion and fix).